### PR TITLE
Add network capability to make this run on HA Supervised on Debian 12

### DIFF
--- a/setecna/apparmor.txt
+++ b/setecna/apparmor.txt
@@ -6,6 +6,7 @@ profile setecna flags=(attach_disconnected,mediate_deleted) {
   # Capabilities
   file,
   signal (send) set=(kill,term,int,hup,cont),
+  network,
 
   # S6-Overlay
   /init ix,


### PR DESCRIPTION
I'm getting this on a fresh installation on Debian 12

```
services-up: info: copying legacy longrun setecna (no readiness notification)
curl: (7) Failed to connect to supervisor port 80 after 0 ms: Could not connect to server
[21:26:40] ERROR: Something went wrong contacting the API
s6-rc: info: service legacy-services successfully started
curl: (7) Failed to connect to supervisor port 80 after 0 ms: Could not connect to server
[21:26:40] ERROR: Something went wrong contacting the API
[21:26:40] INFO: 
2024/12/14 21:26:40 adv_int parameter non specified, default is false
2024/12/14 21:26:40 readonly parameter non specified, default is true
panic: network Error : dial tcp :1883: socket: permission denied
goroutine 1 [running]:
github.com/Ingordigia/homeassistant-addon-setecna/pkg/mqtt.(*MqttServer).Connect(0xc000014e50, {0xc000018080, 0x0}, {0xc000018000, 0x0}, {0xc000018010, 0x0})
	/app/pkg/mqtt/mqtt.go:30 +0x2b7
main.main()
	/app/cmd/main.go:43 +0x10f
[20:26:40] WARNING: Halt add-on with exit code 2
```

Adding `network` capability to apparmor makes the add-on start.

See https://github.com/habuild/hassio-addons/issues/75#issuecomment-1643000662

